### PR TITLE
Create MANIFEST.in, fixes #1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft aiohttp_rest_api/swagger_ui


### PR DESCRIPTION
The problem in #1 was the fact that `include_package_data` requires some list of files to include - it can be either a `package_data` property of setup, or (preferred) a MANIFEST.in file